### PR TITLE
Fix build number typo

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
 # followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
+# Both the version and the build number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # In Android, build-name is used as versionName while build-number used as versionCode.
 # Read more about Android versioning at https://developer.android.com/studio/publish/versioning


### PR DESCRIPTION
## Summary
- fix a typo in pubspec.yaml around versioning instructions

## Testing
- `apt-get update` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840dc8b7ea08333a027f1046f510afc