### PR TITLE
Update widget tests for GameScreen

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,22 +9,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fluttergit/main.dart';
+import 'package:fluttergit/game_screen.dart';
+import 'package:fluttergit/road_widget.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('shows GameScreen on launch', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    expect(find.byType(GameScreen), findsOneWidget);
+    expect(find.text('Color Switch Game'), findsOneWidget);
+  });
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+  testWidgets('contains four lanes', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: GameScreen()));
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byType(RoadWidget), findsNWidgets(4));
   });
 }


### PR DESCRIPTION
## Summary
- replace counter widget test with GameScreen tests
- verify GameScreen loads and lane count

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dc90193c8333bf60f39ff8239ada